### PR TITLE
handle undefined vbox_guest_missing_deps

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
   dnf:
     name: "{{ vbox_guest_missing_deps }}"
     state: absent
+  when: vbox_guest_missing_deps is defined
 
 - name: Find /var/log/vboxadd-* logs
   find:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,8 @@
   dnf:
     name: "{{ vbox_guest_missing_deps }}"
     state: latest
+  when: vbox_guest_missing_deps is defined
+
 
 - name: Mount VBoxGuestAdditions.iso
   mount:


### PR DESCRIPTION
When there is no missing dependencies in "Detect missing VirtualBox Guest Additions dependencies" rule then "Install VirtualBox Guest Additions dependencies" rule cannot proceed as vbox_guest_missing_deps is undefined. Example logs:

    virtualbox-iso.almalinux-8: TASK [ezamriy.vbox_guest : Detect missing VirtualBox Guest Additions dependencies] ***
    virtualbox-iso.almalinux-8: skipping: [default] => (item=elfutils-libelf-devel)
    virtualbox-iso.almalinux-8: skipping: [default] => (item=gcc)
    virtualbox-iso.almalinux-8: skipping: [default] => (item=kernel-devel)
    virtualbox-iso.almalinux-8: skipping: [default] => (item=kernel-headers)
    virtualbox-iso.almalinux-8: skipping: [default] => (item=make)                                                                          
    virtualbox-iso.almalinux-8: skipping: [default] => (item=perl)                                                                          
    virtualbox-iso.almalinux-8:                                                                                                             
    virtualbox-iso.almalinux-8: TASK [ezamriy.vbox_guest : Install VirtualBox Guest Additions dependencies] ****
    virtualbox-iso.almalinux-8: fatal: [default]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'vbox_guest_missing_deps' is undefined..."}