### PR TITLE
Fix the deletion of /mnt while unmount Guest ISO

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     fstype: iso9660
     opts: loop
     state: mounted
+    fstab: /tmp/tmp.fstab
 
 - name: Install VirtualBox Guest Additions
   command: /mnt/VBoxLinuxAdditions.run --nox11
@@ -37,7 +38,10 @@
   mount:
     path: /mnt
     src: "{{ vbox_additions_iso_path }}"
-    state: absent
+    fstype: iso9660
+    opts: loop
+    state: unmounted
+    fstab: /tmp/tmp.fstab
 
 - name: Remove VBoxGuestAdditions.iso
   file:


### PR DESCRIPTION
Using the "state: absent" for ansible.posix.mount module
on "Unmount VBoxGuestAdditions.iso" task, deletes the mounpoint,
in this case, it's the `/mnt` directory.
On the other hand, using the "state: unmounted" results stuck
the Vagrant box while the creation of the VMs.

Propose: Since it's a temporary ISO mount and unmount procedure,
let's use a temporary fstab and do not touch the /etc/fstab at all.

There's a long-awaited PR for adding "state: ephemeral"
support to the ansible.posix.mount module[^1].
We can switch to use this option after the PR merged to the upstream.

This patch can be tested on
https://app.vagrantup.com/almalinux/boxes/8/versions/8.6.20220715
and https://app.vagrantup.com/almalinux/boxes/9/versions/9.0.20220715
Vagrant boxes.

Fixes: https://github.com/AlmaLinux/cloud-images/issues/72

[^1]: https://github.com/ansible-collections/ansible.posix/pull/267

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>